### PR TITLE
ViewPropTypes 오류 관련 패치

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -7,10 +7,9 @@ import {
   PanResponder,
   View,
   Easing,
-  ViewPropTypes,
   I18nManager,
 } from 'react-native';
-
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
 import PropTypes from 'prop-types';
 
 const TRACK_SIZE = 4;
@@ -146,7 +145,7 @@ export default class Slider extends PureComponent {
     /**
      * Sets an image for the thumb.
      */
-    thumbImage: Image.propTypes.source,
+    thumbImage: ImagePropTypes.source,
 
     /**
      * Set this to true to visually see the thumb touch rect in green.


### PR DESCRIPTION
RN 0.76.7 업그레이드 중 타입오류가 발생하여 이를 패치합니다

오류: TypeError: Cannot read property 'style' of undefined.
참고: https://github.com/jeanregisser/react-native-slider/issues/210