### PR TITLE
deprecated-react-native-prop-types를 dependencies에 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "url": "git@github.com:jeanregisser/react-native-slider.git"
   },
   "dependencies": {
-    "prop-types": "^15.5.6"
+    "prop-types": "^15.5.6",
+    "deprecated-react-native-prop-types": "^5.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
https://github.com/Soomgo-Mobile/react-native-slider/pull/1 패치에서 사용된 deprecated-react-native-prop-types를 dependencies에 추가합니다